### PR TITLE
Allow all throwable classes in the filter

### DIFF
--- a/Lib/SentryConfigure.php
+++ b/Lib/SentryConfigure.php
@@ -16,25 +16,26 @@ class SentryConfigure {
      private $defaults = ['traces_sample_rate' => 1.0];
      private $clientConfig = [];
 
-     public function __construct($exceptionIgnoreList = []) {
+     public function __construct($throwableIgnoreList = []) {
          $userConfig = Configure::read('Sentry.init');
          if (is_array($userConfig)) {
              $this->clientConfig = array_merge_recursive($this->defaults, $userConfig);
          }
 
-         $this->addExceptionFilter($exceptionIgnoreList);
+         $this->addThrowableFilter($throwableIgnoreList);
          Sentry\init($this->clientConfig);
      }
 
     /**
-     * Adds an exception filter function to the SentryErrorHandler
-     * @param array $exceptionIgnoreList
+     * Adds an throwable (the root class for both Error & Exception) filter function to the SentryErrorHandler
+     *
+     * @param array $throwableIgnoreList
      * @returns void
      */
-     private function addExceptionFilter($exceptionIgnoreList = []) {
-         SentryErrorHandler::$exceptionFilterFunc = function(Exception $exception) use (&$exceptionIgnoreList): bool {
-             return in_array(get_class($exception), $exceptionIgnoreList);
-         };
-     }
+    private function addThrowableFilter($throwableIgnoreList = []) {
+        SentryErrorHandler::$throwableFilterFunc = function (Throwable $throwable) use (&$throwableIgnoreList): bool {
+            return in_array(get_class($throwable), $throwableIgnoreList);
+        };
+    }
 
 }

--- a/Lib/SentryErrorHandler.php
+++ b/Lib/SentryErrorHandler.php
@@ -9,7 +9,7 @@
 class SentryErrorHandler extends ErrorHandler
 {
 
-    public static $exceptionFilterFunc = null;
+    public static $throwableFilterFunc = null;
 
     public static function handleError($code, $description, $file = null, $line = null, $context = null)
     {
@@ -33,8 +33,8 @@ class SentryErrorHandler extends ErrorHandler
 
         // If the filter returns true, then don't send to sentry as it's in the ignoreList
         if (
-            is_callable(self::$exceptionFilterFunc) &&
-            call_user_func(self::$exceptionFilterFunc, $exception) == true
+            is_callable(self::$throwableFilterFunc) &&
+            call_user_func(self::$throwableFilterFunc, $exception) == true
         ){
             parent::handleException($exception);
             return;

--- a/README.md
+++ b/README.md
@@ -30,21 +30,13 @@ This library is only compatible with CakePHP >= 2.8 and < 3.0. If you need suppo
 CakePlugin::load('Sentry');
 // Setup Sentry configuration
 App::uses('SentryConfigure', 'Sentry.Lib');
-new SentryConfigure();
-```
-
-You can add Exception classes to the ignore list here as well:
-
-```php
 new SentryConfigure([
+  // Ignore the following Exceptions:
+  // (any Throwable class is valid here)
   MissingControllerException::class,
-  MissingActionException::class
+  MissingActionException::class,
 ]);
 ```
-
-Underneath the hood, the filtering logic is a closure, so you can
-create your own filter rules easily. Take a look at the `SentryConfigure`
-class if you need help.
 
 3. Configure the error handler in your _core.php_ :
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "sandreu/cake-sentry",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "cakephp-plugin",
   "description": "Sentry error handler plugin for CakePHP2",
   "keywords": ["Sentry", "CakePHP", "Log", "Error", "Exception"],


### PR DESCRIPTION
Fixes a bug where what was called the ExceptionFilter would only accept
classes derived from the Exception class - this was not correct as
Error-derived classes will also enter this codepath.

Research found that the root parent class for both Exception and Error
is Throwable, and such the filter is now accepting any Throwable class.